### PR TITLE
Safari 11 Support

### DIFF
--- a/lib/WebRtcPeer.js
+++ b/lib/WebRtcPeer.js
@@ -425,18 +425,17 @@ function WebRtcPeer(mode, options, callback) {
   function setRemoteVideo() {
     if (remoteVideo) {
       var stream = pc.getRemoteStreams()[0]
-      var url = stream ? URL.createObjectURL(stream) : ''
 
       remoteVideo.pause()
-      remoteVideo.src = url
+      remoteVideo.srcObject = stream
       remoteVideo.load()
 
-      logger.debug('Remote URL:', url)
+      logger.info('Remote URL:', remoteVideo.srcObject)
     }
   }
 
   this.showLocalVideo = function () {
-    localVideo.src = URL.createObjectURL(videoStream)
+    localVideo.srcObject = videoStream
     localVideo.muted = true
   }
 


### PR DESCRIPTION
"To support Safari 11's introduction of WebRTC, we need to stop using the deprecated HTMLMediaElement.src=URL.createObjectUrl(stream) since Safari does not support this, at least not with the latest beta of iOS11 and MacOS High Sierra as of Sep 15 2017.

 We switch from setting the stream via URL.createObjectURL to srcObject. All major browsers supports srcObject a few releases before they supported RTCPeerConnection, so we should be safe with this change without any fallback. E.g. Chrome supports srcObject since Chrome 52 but RTCPeerConnection since Chrome 56. FireFox supports srcObject since FF18 but RTCPeerConnection since FF22."